### PR TITLE
refactor the pip install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Installation:
 
     $ git clone https://github.com/anshulc95/exch.git
     $ cd exch
-    $ pip install -e . -r requirements.txt  
+    $ pip install . -r requirements.txt  
 
 Usage:
 ------
@@ -73,7 +73,7 @@ Install the testing dependecies:
     /home/username/somedir/exch
     $ virtualenv venv -p python3
     $ source venv/bin/activate
-    (venv) $ pip install -r requirements.txt -r test-requirements.txt
+    (venv) $ pip install -e . -r requirements.txt -r test-requirements.txt
 
 Running the tests
 ~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,13 @@ setup(
     author_email='anshulchauhan@outlook.com',
     license='MIT',
     py_modules=['exch'],
+    tests_require=['pytest'],
     install_requires=[
         'Click>=6.7',
-        'requests==2.18.2',
+        'requests>=2.18.2',
     ],
+    packages=['exch'],
+    include_package_data=True,
     entry_points='''
         [console_scripts]
         exch=exch.cli:cli


### PR DESCRIPTION
Add the packages details in the _setup.py,_ after this pip no more
requires the `--editable` tag to install properly.