### PR TITLE
add support for python2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *.egg-info
 .cache
 .coverage
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "3.5"
 # command to install dependencies
-install: "pip install -e . -r requirements.txt -r test-requirements.txt"
+install: "pip install . -r requirements.txt -r test-requirements.txt"
 # command to run tests
-script: pytest
+script: tox

--- a/exch/helpers.py
+++ b/exch/helpers.py
@@ -1,16 +1,15 @@
 """ helper functions to gather the currency rates """
 
-from urllib.parse import urlencode
 import requests
 
 def fixer(base, target, value, date='latest'):
     """get currency exchange rate from fixer.io in JSON"""
 
     main_api = 'http://api.fixer.io/{}?'.format(date)
-    url = main_api + urlencode({'base':base})
+    url = requests.get(main_api, params={'base':base})
 
     try:
-        json_data = requests.get(url).json()
+        json_data = requests.get(url.url).json()
         result = round(json_data['rates'][target] * value, 2)
     except requests.exceptions.ConnectionError:
         result = "Connection Error"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
+tox==2.7.0
 pytest==3.2.1
 pytest-cov==2.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27, py35
+[testenv]
+deps=pytest
+commands=py.test


### PR DESCRIPTION
removed the `urllib` and used the `requests` instead to support both python 2.7 and python 3.5