### PR TITLE
Exception handling request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 *.egg-info
 .cache
 .coverage
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "3.5"
 # command to install dependencies
-install: "pip install -e . -r requirements.txt -r test-requirements.txt"
+install: "pip install . -r requirements.txt -r test-requirements.txt"
 # command to run tests
-script: pytest
+script: tox

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Installation:
 
     $ git clone https://github.com/anshulc95/exch.git
     $ cd exch
-    $ pip install -e . -r requirements.txt  
+    $ pip install . -r requirements.txt  
 
 Usage:
 ------
@@ -73,7 +73,7 @@ Install the testing dependecies:
     /home/username/somedir/exch
     $ virtualenv venv -p python3
     $ source venv/bin/activate
-    (venv) $ pip install -r requirements.txt -r test-requirements.txt
+    (venv) $ pip install -e . -r requirements.txt -r test-requirements.txt
 
 Running the tests
 ~~~~~~~~~~~~~~~~~

--- a/exch/helpers.py
+++ b/exch/helpers.py
@@ -14,7 +14,7 @@ def fixer(base, target, value, date='latest'):
     except requests.exceptions.ConnectionError:
         result = "Connection Error"
     except KeyError:
-        result = 1.00 if (base == target) else "Invalid currency"
+        result = 1.00 if base == target else "KeyError: Invalid curreny"
 
     return result
 

--- a/exch/helpers.py
+++ b/exch/helpers.py
@@ -1,16 +1,15 @@
 """ helper functions to gather the currency rates """
 
-from urllib.parse import urlencode
 import requests
 
 def fixer(base, target, value, date='latest'):
     """get currency exchange rate from fixer.io in JSON"""
 
     main_api = 'http://api.fixer.io/{}?'.format(date)
-    url = main_api + urlencode({'base':base})
+    url = requests.get(main_api, params={'base':base})
 
     try:
-        json_data = requests.get(url).json()
+        json_data = requests.get(url.url).json()
         result = round(json_data['rates'][target] * value, 2)
     except requests.exceptions.ConnectionError:
         result = "Connection Error"

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,13 @@ setup(
     author_email='anshulchauhan@outlook.com',
     license='MIT',
     py_modules=['exch'],
+    tests_require=['pytest'],
     install_requires=[
         'Click>=6.7',
-        'requests==2.18.2',
+        'requests>=2.18.2',
     ],
+    packages=['exch'],
+    include_package_data=True,
     entry_points='''
         [console_scripts]
         exch=exch.cli:cli

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
+tox==2.7.0
 pytest==3.2.1
 pytest-cov==2.5.1

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -18,12 +18,12 @@ def test_click_same_currency_code():
 def test_invalid_base_currency_code():
     result = runner().invoke(cli, ['-t', 'USD', '-b', 'AAA'])
     assert result.exit_code == 0
-    assert result.output == "Invalid currency\n"
+    assert result.output == "KeyError: Invalid curreny\n"
 
 def test_invalid_target_currency_code():
     result = runner().invoke(cli, ['-t', 'OOO'])
     assert result.exit_code == 0
-    assert result.output == "Invalid currency\n"
+    assert result.output == "KeyError: Invalid curreny\n"
 
 def test_invalid_amount_value():
     result = runner().invoke(cli, ['-a', 'TT'])

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,5 +21,4 @@ def test_fixer_gbp_to_php_value_99():
 
 def test_fixer_invalid_currency():
     """ when invalid currency is passed to fixer.io """
-    assert fixer('USD', 'TTT', 1) == "Invalid currency"
-    assert fixer('HHRR', 'TTT', 1) == "Invalid currency"
+    assert fixer('USD', 'TTT', 1) == "KeyError: Invalid curreny"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27, py35
+[testenv]
+deps=pytest
+commands=py.test


### PR DESCRIPTION
Though I didn't achieve the goal I had in mind, I did learn something.
So, I think I have found a workaround for my issue,
I was getting this from `pytest`:
```
>       assert result.exception == KeyError()
E       assert KeyError() == KeyError()
E        +  where KeyError() = <Result KeyError()>.exception
E        +  and   KeyError() = KeyError()

tests/test_advanced.py:21: AssertionError
```
but now I changed the line a little bit:
```diff
-    assert result.exception == KeyError()
+    assert type(result.exception) == type(KeyError())
```
and to give you some clarity:
```python
>>> type(KeyError())
<class 'KeyError'>
>>> type(KeyError)
<class 'type'>
>>> type(KeyError()) == type(ValueError())
False
>>> type(KeyError) == type(ValueError)
True
```

but later I realised I am inside a bad pattern, I was catching and exception with `except` and raising it again with `raise`. 